### PR TITLE
Fix SimpleCov add_filter deprecation; treat Ruby 4.0 as stable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1.316.0
         with:
-          ruby-version: '4.0.5'
+          ruby-version: '4.0'
           bundler-cache: true
           bundler: 'latest'
       - name: Run rubocop
@@ -49,7 +49,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1.316.0
         with:
-          ruby-version: '4.0.5'
+          ruby-version: '4.0'
           bundler-cache: true
           bundler: 'latest'
 
@@ -75,7 +75,7 @@ jobs:
           - false
         include:
           - os: ubuntu-latest
-            ruby: '3.4'
+            ruby: '4.0'
             coverage: 'true'
           - os: macos-latest
             ruby: '3.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,6 @@ GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.6.2)
-    docile (1.4.1)
     ffi (1.17.4)
     ffi (1.17.4-aarch64-linux-gnu)
     ffi (1.17.4-aarch64-linux-musl)
@@ -34,12 +33,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.7)
-    simplecov (0.22.0)
-      docile (~> 1.1)
-      simplecov-html (~> 0.11)
-      simplecov_json_formatter (~> 0.1)
-    simplecov-html (0.13.2)
-    simplecov_json_formatter (0.1.4)
+    simplecov (1.0.0)
     warning (1.6.0)
 
 PLATFORMS

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,11 +24,11 @@ require "simplecov"
 
 # Don't include unnecessary stuff into SimpleCov
 SimpleCov.start do
-  add_filter "/vendor/"
-  add_filter "/gems/"
-  add_filter "/.bundle/"
-  add_filter "/doc/"
-  add_filter "/spec/"
+  skip "/vendor/"
+  skip "/gems/"
+  skip "/.bundle/"
+  skip "/doc/"
+  skip "/spec/"
 
   merge_timeout 3600
 end


### PR DESCRIPTION
## What

Fixes the SimpleCov `add_filter` deprecation and promotes Ruby 4.0 to a fully supported, gating CI version.

## Changes

**SimpleCov deprecation (`spec/spec_helper.rb`)**
- Replaced the deprecated `add_filter` with `skip` (5 occurrences). `add_filter` emits a deprecation warning under SimpleCov 1.0.

**Dependency lock (`Gemfile.lock`)**
- Locked `simplecov` to `1.0.0`. This drops the now-unbundled `docile`, `simplecov-html`, and `simplecov_json_formatter` transitive deps.

**CI (`.github/workflows/ci.yml`)**
- Ruby 4.0 is treated as a stable, fully-gating matrix version (no `continue-on-error`, no special-casing).
- Coverage reporting moved from Ruby 3.4 to Ruby 4.0.
- Auxiliary jobs (`rubocop`, `yard-lint`) now use `ruby-version: '4.0'` instead of the pinned `'4.0.5'`, so they track 4.0.LATEST.

## Notes

- No Ruby 4.1 anywhere: it does not exist in `setup-ruby` yet.
- The pre-existing "Remove Gemfile.lock for Ruby preview versions" step is left untouched on its original `contains(matrix.ruby, 'preview')` condition.

## Final CI matrix

`ruby: ['4.0', '3.4', '3.3', '3.2']` x `force_ruby_platform: [true, false]`, plus coverage on ubuntu/4.0 and a macOS/3.4 entry.