### PR TITLE
Standardize yard-lint config (em-dash substitution as error)

### DIFF
--- a/.yard-lint.yml
+++ b/.yard-lint.yml
@@ -78,6 +78,14 @@ Documentation/LineLength:
   # Aligned with RuboCop's Layout/LineLength.
   MaxLength: 100
 
+Documentation/TextSubstitution:
+  Description: Detects em/en-dashes in documentation and replaces them with hyphens.
+  Enabled: true
+  Severity: error
+  Substitutions:
+    "—": "-"    # em-dash (U+2014)
+    "–": "-"    # en-dash (U+2013)
+
 # Tags validators
 Tags/Order:
   Description: Enforces consistent ordering of YARD tags.


### PR DESCRIPTION
Enables `Documentation/TextSubstitution` (em-dash `—` and en-dash `–` -> `-`) as an **error**, standardizing it across the ecosystem, and replaces the existing em/en-dashes in documentation. `bundle exec yard-lint lib/` reports `No offenses found`.