### PR TITLE
Backfill missing gemspec metadata

### DIFF
--- a/pidfd.gemspec
+++ b/pidfd.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.metadata["source_code_uri"] = "https://github.com/mensfeld/pidfd"
   spec.metadata["changelog_uri"] = "https://github.com/mensfeld/pidfd/blob/main/CHANGELOG.md"
   spec.metadata["documentation_uri"] = "https://github.com/mensfeld/pidfd#readme"
+  spec.metadata["bug_tracker_uri"] = "https://github.com/mensfeld/pidfd/issues"
   spec.metadata["rubygems_mfa_required"] = "true"
 
   # Specify which files should be added to the gem when it is released.


### PR DESCRIPTION
Adds the `metadata` keys this gem was missing relative to the rest of the fleet (per the gemspec audit): **bug_tracker_uri **

- URIs point at the standard GitHub locations (`/issues` for bug tracker, repo URL for docs/homepage), matching the repo's existing quote/interpolation style.
- Improves the rubygems.org sidebar links.

Gemspec loads cleanly (`Gem::Specification.load`); no other changes.